### PR TITLE
Let height of SVG determine height of bodyVis (not window height), so large SVGs are not truncated

### DIFF
--- a/upset.js
+++ b/upset.js
@@ -2575,11 +2575,11 @@ function UpSet() {
                     height: windowHeight+"px"
                 })
 
-            d3.select('#bodyVis')
-                .style({
+//            d3.select('#bodyVis')
+//                .style({
 //                    height: (windowHeight-2*ctx.textHeight-40)+"px" // TODO: HACK
-                    height: (windowHeight-300)+"px" // TODO: HACK
-                })
+//                    height: (windowHeight-300)+"px" // TODO: HACK
+//                })
 
 //            ctx.svgBody.attr({
 //                height: (windowHeight - 70)


### PR DESCRIPTION
I suspect this solution is naive and has unintended consequences, but I thought I'd send a pull request just in case. It works for me at least.
