### PR TITLE
Remove extra horizontal scroll bar. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
     <!--padding: 0px;-->
     <div class="ui-column ui-layout-center">
-      <div id="set-vis-container" data-height-ratio="1" class="fixed-y-container">
+      <div id="set-vis-container" data-height-ratio="1">
 
         <!--<div class="matrixTableContainer">-->
         <div style="display: table;">


### PR DESCRIPTION
... but the class was probably put there for some reason, so this probably breaks something else?

My sense of the problem is that with `fixed-y-container`, it adds a vertical scrollbar which consumes a tiny bit of horizontal real estate. A different approach would be to hide this x-overflow. Fix #177?
