### PR TITLE
Change "Set" to "USet" to avoid clashing with standard name Set

### DIFF
--- a/dataLoading.js
+++ b/dataLoading.js
@@ -357,7 +357,7 @@ function parseDataSet(data, dataSetDescription) {
     for (var i = 0; i < rawSets.length; i++) {
         var combinedSets = Array.apply(null, new Array(rawSets.length)).map(Number.prototype.valueOf, 0);
         combinedSets[i] = 1;
-        var set = new Set(setPrefix + i, setNames[i], combinedSets, rawSets[i]);
+        var set = new USet(setPrefix + i, setNames[i], combinedSets, rawSets[i]);
         setIdToSet[setPrefix + i] = set;
         sets.push(set);
         if (i < nrDefaultSets) {

--- a/dataStructure.js
+++ b/dataStructure.js
@@ -142,7 +142,7 @@ function BaseSet(setID, setName, combinedSets, setData, fake) {
 BaseSet.prototype = Element;
 BaseSet.prototype.constructor = Element;
 
-function Set(setID, setName, combinedSets, itemList) {
+function USet(setID, setName, combinedSets, itemList) {
     BaseSet.call(this, setID, setName, combinedSets,[],1);
         for (var i = 0; i < itemList.length; i++) {
         if (itemList[i] !== 0) {
@@ -159,8 +159,8 @@ function Set(setID, setName, combinedSets, itemList) {
 
 }
 
-Set.prototype = BaseSet;
-Set.prototype.constructor = BaseSet;
+USet.prototype = BaseSet;
+USet.prototype.constructor = BaseSet;
 
 function SubSet(setID, setName, combinedSets, itemList, expectedProb) {
     BaseSet.call(this, setID, setName, combinedSets, itemList);
@@ -184,7 +184,7 @@ SubSet.prototype.toString = function () {
 }
 
 // Not sure how to do this properly with parameters?
-SubSet.prototype = Set;
+SubSet.prototype = USet;
 SubSet.prototype.constructor = SubSet;
 
 function Group(groupID, groupName, level) {


### PR DESCRIPTION
Overriding the name `Set` in `dataStructures.js` leads to a clash with the standard `Set` class as available in ES2015 environments.

This change averts the clash, though in the longer term, UpSet should consider restructuring to use module exports instead of the current practice. This would prevent the problem entirely before it can even start.

(Background: we include UpSet as a wrapped visualization component [in Candela](https://github.com/Kitware/candela/tree/webpack-helper/components/UpSet), and this name clash causes trouble for other Candela components.)